### PR TITLE
Fix Object.assign() race condition

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ function convertCrontabs() {
         delete schedule.timezone;
         // append new utc crontab schedule events
         this.serverless.service.functions[funcName].events.push(...newCrontabs.map((crontab) => ({
-          schedule: Object.assign(schedule, {rate: `cron(${crontab})`}),
+          schedule: Object.assign({}, schedule, {rate: `cron(${crontab})`}),
         })))
       }
     }


### PR DESCRIPTION
Effectively create a new instance of schedule for each new crontab entry.

Without this change I am seeing the same schedule expression duplicated 6 times instead of 6 different expressions. 