### PR TITLE
fix #15 issue ('Cannot read property 'hasOwnProperty' of null')

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,15 +61,14 @@ function convertCrontabs() {
   for (const funcName in this.serverless.service.functions) {
     for (const eventIndex in this.serverless.service.functions[funcName]
       .events) {
-      const event = this.serverless.service.functions[funcName].events[
+      const schedule = this.serverless.service.functions[funcName].events[
         eventIndex
       ];
       // only process events with a schedule & a timezone
       if (
-        event.hasOwnProperty("schedule") &&
-        event.schedule.hasOwnProperty("timezone")
+        schedule.hasOwnProperty("rate") &&
+        schedule.hasOwnProperty("timezone")
       ) {
-        const schedule = event.schedule;
         const match = schedule.rate.match(/^cron\((.*)\)$/);
         if (!match)
           // skip rate() schedules


### PR DESCRIPTION
Resolves issue #15 :

```
Serverless:
Serverless: Converting local crontabs to UTC crontabs...
Serverless: [object Object]

  Type Error ---------------------------------------------

  TypeError: Cannot read property 'hasOwnProperty' of null
      at ServerlessLocalCrontabs.convertCrontabs (/Users/kkarczmarczyk/repo/harvey-serverless/node_modules/serverless-local-schedule/index.js:71:24)
      at /Users/kkarczmarczyk/.nvm/versions/node/v14.12.0/lib/node_modules/serverless/lib/classes/PluginManager.js:510:55
      at tryCatcher (/Users/kkarczmarczyk/.nvm/versions/node/v14.12.0/lib/node_modules/serverless/node_modules/bluebird/js/release/util.js:16:23)
      at Object.gotValue (/Users/kkarczmarczyk/.nvm/versions/node/v14.12.0/lib/node_modules/serverless/node_modules/bluebird/js/release/reduce.js:168:18)
      at Object.gotAccum (/Users/kkarczmarczyk/.nvm/versions/node/v14.12.0/lib/node_modules/serverless/node_modules/bluebird/js/release/reduce.js:155:25)
      at Object.tryCatcher (/Users/kkarczmarczyk/.nvm/versions/node/v14.12.0/lib/node_modules/serverless/node_modules/bluebird/js/release/util.js:16:23)
      at Promise._settlePromiseFromHandler (/Users/kkarczmarczyk/.nvm/versions/node/v14.12.0/lib/node_modules/serverless/node_modules/bluebird/js/release/promise.js:547:31)
      at Promise._settlePromise (/Users/kkarczmarczyk/.nvm/versions/node/v14.12.0/lib/node_modules/serverless/node_modules/bluebird/js/release/promise.js:604:18)
      at Promise._settlePromise0 (/Users/kkarczmarczyk/.nvm/versions/node/v14.12.0/lib/node_modules/serverless/node_modules/bluebird/js/release/promise.js:649:10)
      at Promise._settlePromises (/Users/kkarczmarczyk/.nvm/versions/node/v14.12.0/lib/node_modules/serverless/node_modules/bluebird/js/release/promise.js:729:18)
      at _drainQueueStep (/Users/kkarczmarczyk/.nvm/versions/node/v14.12.0/lib/node_modules/serverless/node_modules/bluebird/js/release/async.js:93:12)
      at _drainQueue (/Users/kkarczmarczyk/.nvm/versions/node/v14.12.0/lib/node_modules/serverless/node_modules/bluebird/js/release/async.js:86:9)
      at Async._drainQueues (/Users/kkarczmarczyk/.nvm/versions/node/v14.12.0/lib/node_modules/serverless/node_modules/bluebird/js/release/async.js:102:5)
      at Immediate.Async.drainQueues [as _onImmediate] (/Users/kkarczmarczyk/.nvm/versions/node/v14.12.0/lib/node_modules/serverless/node_modules/bluebird/js/release/async.js:15:14)
      at processImmediate (internal/timers.js:461:21)

     For debugging logs, run again after setting the "SLS_DEBUG=*" environment variable.

  Get Support --------------------------------------------
     Docs:          docs.serverless.com
     Bugs:          github.com/serverless/serverless/issues
     Issues:        forum.serverless.com

  Your Environment Information ---------------------------
     Operating System:          darwin
     Node Version:              14.12.0
     Framework Version:         2.8.0
     Plugin Version:            4.1.1
     SDK Version:               2.3.2
     Components Version:        3.2.7
```