### PR TITLE
Fix rate.match is not a function issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,8 @@ function convertCrontabs() {
         event.schedule.hasOwnProperty("timezone")
       ) {
         const schedule = event.schedule;
-        const match = schedule.rate.match(/^cron\((.*)\)$/);
+        const rate = Array.isArray(schedule.rate) ? schedule.rate[0] : schedule.rate;
+        const match = rate.match(/^cron\((.*)\)$/);
         if (!match)
           // skip rate() schedules
           continue;


### PR DESCRIPTION
FIXES: https://github.com/UnitedIncome/serverless-local-schedule/issues/20

Solution by https://github.com/UnitedIncome/serverless-local-schedule/issues/20#issuecomment-924749622