### PR TITLE
fix: Support `schedule.rate` defined as an array

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,7 +71,9 @@ function convertCrontabs() {
         event.schedule.hasOwnProperty("timezone")
       ) {
         const schedule = event.schedule;
-        const rates = Array.isArray(schedule.rate) ? schedule.rate : [schedule.rate];
+        const isNewServerlessVersion = Array.isArray(schedule.rate);
+
+        const rates = isNewServerlessVersion ? schedule.rate : [schedule.rate];
         const matches = rates
           .map(rate => rate.match(/^cron\((.*)\)$/))
           .filter(match => match && match[1])
@@ -103,11 +105,16 @@ function convertCrontabs() {
         };
         newCrontabsMap[funcName].removeIndexes.splice(0, 0, eventIndex);
         newCrontabsMap[funcName].newCrontabs.push(
-          ...newCrontabs.map((crontab, i) => ({
-            schedule: Object.assign({}, schedule, {
-              rate: `cron(${crontab})`,
-            })
-          }))
+          ...newCrontabs.map((crontab, i) => {
+            const addName = !isNewServerlessVersion && schedule.name;
+
+            return ({
+              schedule: Object.assign({}, schedule, {
+                rate: `cron(${crontab})`,
+                name: addName ? `${schedule.name}-${i}` : undefined,
+              })
+            });
+          })
         );
       }
     }

--- a/index.js
+++ b/index.js
@@ -71,9 +71,9 @@ function convertCrontabs() {
         event.schedule.hasOwnProperty("timezone")
       ) {
         const schedule = event.schedule;
-        const isNewServerlessVersion = Array.isArray(schedule.rate);
+        const ratesAreArray = Array.isArray(schedule.rate);
 
-        const rates = isNewServerlessVersion ? schedule.rate : [schedule.rate];
+        const rates = ratesAreArray ? schedule.rate : [schedule.rate];
         const matches = rates
           .map(rate => rate.match(/^cron\((.*)\)$/))
           .filter(match => match && match[1])
@@ -106,7 +106,10 @@ function convertCrontabs() {
         newCrontabsMap[funcName].removeIndexes.splice(0, 0, eventIndex);
         newCrontabsMap[funcName].newCrontabs.push(
           ...newCrontabs.map((crontab, i) => {
-            const addName = !isNewServerlessVersion && schedule.name;
+            // When the rates are an array, the version of Serverless being used
+            // is one that doesn't support named schedules when there are multiple
+            // schedules or rates. See https://github.com/serverless/serverless/issues/9867 for details.
+            const addName = !ratesAreArray && schedule.name;
 
             return ({
               schedule: Object.assign({}, schedule, {

--- a/index.js
+++ b/index.js
@@ -71,20 +71,29 @@ function convertCrontabs() {
         event.schedule.hasOwnProperty("timezone")
       ) {
         const schedule = event.schedule;
-        const match = schedule.rate.match(/^cron\((.*)\)$/);
-        if (!match)
+        const rates = Array.isArray(schedule.rate) ? schedule.rate : [schedule.rate];
+        const matches = rates
+          .map(rate => rate.match(/^cron\((.*)\)$/))
+          .filter(match => match && match[1])
+
+        if (!matches.length)
           // skip rate() schedules
           continue;
         // convert the local crontab to utc crontabs
-        const newCrontabs = convertAwsLocalCrontabToAwsUtcCrontab(
-          match[1],
-          schedule.timezone
-        );
+        const newCrontabs = matches.flatMap(match => {
+          const convertedCrontabs = convertAwsLocalCrontabToAwsUtcCrontab(
+            match[1],
+            schedule.timezone
+          );
 
-        if (this.options.verbose || this.options.v) {
-          this.serverless.cli.log(`Converted ${match[1]} ${schedule.timezone} to
-               ${newCrontabs.join("\n               ")}`);
-        }
+          if (this.options.verbose || this.options.v) {
+            this.serverless.cli.log(`Converted ${match[1]} ${schedule.timezone} to
+               ${convertedCrontabs.join("\n               ")}`);
+          }
+
+          return convertedCrontabs;
+        })
+
         // remove timezone from original schedule event
         delete schedule.timezone;
         // append new utc crontab schedule events
@@ -97,7 +106,6 @@ function convertCrontabs() {
           ...newCrontabs.map((crontab, i) => ({
             schedule: Object.assign({}, schedule, {
               rate: `cron(${crontab})`,
-              name: schedule.name && `${schedule.name}-${i}`
             })
           }))
         );

--- a/test-service/serverless.yml
+++ b/test-service/serverless.yml
@@ -15,8 +15,12 @@ functions:
     events:
       - schedule:
           rate: cron(0 10 * * ? *)
-          name: test-crontab
           timezone: America/New_York
       - schedule:
           rate: cron(0 5 * * ? *)
+          timezone: America/New_York
+      - schedule:
+          rate:
+            - cron(0 15 * * ? *)
+            - cron(0 20 * * ? *)
           timezone: America/New_York


### PR DESCRIPTION
Fixes https://github.com/serverless/serverless-local-schedule/issues/20
* This code works correctly when multiple crontabs are configured in one schedule
* This code will also fallback correctly if schedule.rate is still a string and not an array.

* When serverless added the ability to configure multiple rates in a schedule, they also removed the ability to set names when configuring multiple schedules. https://github.com/serverless/serverless/issues/9867 This was causing my local testing to fail.
   * This means we shouldn't add a numbered name to schedules
   * I've also removed the name in the test schedule